### PR TITLE
Use hostname with FQDN as a default name for host

### DIFF
--- a/etc/backup/local.config
+++ b/etc/backup/local.config
@@ -1,3 +1,3 @@
-BACKUP_HOSTNAME="backuphost.example.org"
+BACKUP_HOSTNAME=$(hostname -f)
 BACKUP_DIR="/"
 # HEALTHCHECK_URL="<URL from https://healthchecks.io/checks/ to notify>"


### PR DESCRIPTION
User might override if needed, but would be OK for quick setup.