### PR TITLE
Support multiple backup sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,16 @@
 Wrapper around restic backup to simplify certain tasks. 
 Repositories can be configured in `/etc/backup/$REPO.repo`. 
 Local includes and excludes in `/etc/backup/local.config` or `/etc/backup/local.exclude`
+Arbitrary backup set includes and excludes in `/etc/backup/XXX.config` or `/etc/backup/XXX.exclude`
+
+Note that if arbitrary backup set names conflict with restic command names it will not be possible to run the conflicting commands, as the backup set name takes precedence.
 
 * `backup $REPO local` for local backup to repo configured by 
+* `backup $REPO XXX` for XXX backup to repo configured by 
 * `backup $REPO monitor $HOST $WARN_HOURS $CRIT_HOURS` for Nagios/Icinga checks of backups
 * `backup $REPO $ARGUMENTS` for invoking restic with $ARGUMENTS for the repository
 
-In `local.config`:
+In `local.config` or `XXX.config`:
 * `BACKUP_HOSTNAME` is the name your host will show up as in restic
 * `BACKUP_DIR` is the root of the directory you want to back up
 * `HEALTHCHECK_URL` is an optional URL to [healthchecks.io](https://healthchecks.io/checks/) (comment out if you don't need it)

--- a/bin/backup
+++ b/bin/backup
@@ -2,7 +2,7 @@
 set -uo pipefail
 
 display_usage() {
-	echo "Usage: $0 <repo> (local|monitor <host> <warning> <critical>|restic arguments)" >&2
+	echo "Usage: $0 <repo> (<backup set>|monitor <host> <warning> <critical>|restic arguments)" >&2
 }
 
 if [ "$#" -lt 2 ]; then
@@ -34,9 +34,9 @@ check_config() {
 }
 
 handle_params () {
-
-	if [ $2 == "local" ]; then
-    		do_local_backup
+  CONFIG=/etc/backup/$2.config
+  if [ -f $CONFIG ]; then
+	  		do_backup $CONFIG
 	elif [ $2 == "monitor" ]; then
 		do_monitor $@
 	else
@@ -46,25 +46,35 @@ handle_params () {
 }
 
 
-do_local_backup () {
-        if [ ! -f /etc/backup/local.config ]; then
-                echo "local backup config file $/etc/backup/local.config not found!"
-                exit 1
-        fi
+do_backup () {
+  CONFIG=$1
+  PRE=${1%.config}.pre
+  POST=${1%.config}.post
+  EXCLUDE=${1%.config}.exclude
+  
+  if [ ! -f $CONFIG ]; then
+          echo "backup config file $CONFIG not found!"
+          exit 1
+  fi
 
-	. /etc/backup/local.config
+  if [ ! -f $EXCLUDE ]; then
+          echo "backup exclude file $EXCLUDE not found!"
+          exit 1
+  fi
+
+	. $CONFIG
 
 	# define an empty default if BACKUP_ARGS is not set
 	BACKUP_ARGS=${BACKUP_ARGS:-""}
 
-        if [[ -x /etc/backup/local.pre ]]; then
-        	/etc/backup/local.pre $TARGET
+  if [[ -x $PRE ]]; then
+    $PRE $TARGET
  	fi
 
-	$RESTIC --exclude-file /etc/backup/local.exclude backup --hostname $BACKUP_HOSTNAME $BACKUP_ARGS $BACKUP_DIR
+	$RESTIC --exclude-file $EXCLUDE backup --hostname $BACKUP_HOSTNAME $BACKUP_ARGS $BACKUP_DIR
 
-        if [[ -x /etc/backup/local.post ]]; then
-                /etc/backup/local.post $TARGET
+        if [[ -x $POST ]]; then
+                $POST $TARGET
 	fi
 
 	if [[ -n "${HEALTHCHECK_URL:-}" ]]; then


### PR DESCRIPTION
Allows the creation of multiple backup sets by creating additional .config and .exclude files in the /etc/backup directory.
Useful if you need to ensure some locations on your file system are backed up more regularly than others, to different locations, etc.